### PR TITLE
Support conditionCheck operation in the local mock

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,8 +59,15 @@ function createLocalDb(endpointURL) {
       RequestItems: {}
     };
     request.TransactItems.forEach((item) => {
-      const operation = Object.keys(item)[0];
+      let operation = Object.keys(item)[0];
       const transactItem = item[operation];
+
+      if (operation === 'ConditionCheck') {
+        // Mock does not support ConditionCheck operation, so just fail silently.
+        // Bail out early to not create a request with empty table name.
+        return;
+      }
+
       if (!batchRequest.RequestItems[transactItem.TableName]) {
         batchRequest.RequestItems[transactItem.TableName] = [];
       }
@@ -79,9 +86,13 @@ function createLocalDb(endpointURL) {
         itemValue.Item = Item;
       }
 
+      if (operation === 'Update') {
+        // Map Update operation to Put, as this mock does not support Update operations.
+        operation = 'Put';
+      }
+
       batchRequest.RequestItems[transactItem.TableName].push({
-        // Map Update operation to Put.
-        [`${operation === 'Update' ? 'Put' : operation}Request`]: itemValue
+        [`${operation}Request`]: itemValue
       })
     });
     return client.batchWriteItem(batchRequest, callback);


### PR DESCRIPTION
### Summary:

Updates mock to remove condition check requests. Currently there's no nice way to emulate that, so we just have to filter it out. Local support for transactions can't come quick enough.
